### PR TITLE
貸出情報を更新するDB操作関数を実装

### DIFF
--- a/.sqlx/query-b2919f5716bf8be30ba1cd1446ecff8549f8afebdd29c05df92b007882976d05.json
+++ b/.sqlx/query-b2919f5716bf8be30ba1cd1446ecff8549f8afebdd29c05df92b007882976d05.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE lending SET\n            fixtures_id=$2,\n            spot_name=$3,\n            lending_at=$4,\n            returned_at=$5,\n            borrower_name=$6,\n            borrower_number=$7,\n            borrower_org=$8\n          WHERE id=$1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Timestamptz",
+        "Timestamptz",
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b2919f5716bf8be30ba1cd1446ecff8549f8afebdd29c05df92b007882976d05"
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -27,6 +27,8 @@ pub mod insert_lending;
 pub mod insert_spot;
 /// 返却処理を行う関数を提供する
 pub mod returned_lending;
+/// 貸出情報の更新を行う関数を提供する
+pub mod update_lending;
 /// 地点情報の変更を行う関数を提供する
 pub mod update_spot;
 

--- a/src/database/update_lending.rs
+++ b/src/database/update_lending.rs
@@ -1,0 +1,81 @@
+use crate::Lending;
+use anyhow::{Context, Result};
+
+/// 貸し出し情報のアップデートを行う
+pub async fn update_lending<'a, E>(conn: E, new_info: Lending) -> Result<()>
+where
+    E: sqlx::Executor<'a, Database = sqlx::Postgres>,
+{
+    let Lending {
+        id,
+        fixtures_id,
+        spot_name,
+        lending_at,
+        returned_at,
+        borrower_name,
+        borrower_number,
+        borrower_org,
+    } = new_info;
+    sqlx::query!(
+        r#"UPDATE lending SET
+            fixtures_id=$2,
+            spot_name=$3,
+            lending_at=$4,
+            returned_at=$5,
+            borrower_name=$6,
+            borrower_number=$7,
+            borrower_org=$8
+          WHERE id=$1"#,
+        id,
+        fixtures_id,
+        spot_name,
+        lending_at,
+        returned_at,
+        borrower_name,
+        borrower_number,
+        borrower_org
+    )
+    .execute(conn)
+    .await
+    .context("Failed to update to lending")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::insert_lending::insert_lending;
+    use crate::database::update_lending::update_lending;
+    use sqlx::{pool::Pool, Postgres};
+    use uuid::uuid;
+    #[sqlx::test(migrations = "./migrations")]
+    async fn test_insert_spot_sql(pool: Pool<Postgres>) {
+        let id = uuid!("550e8400-e29b-41d4-a716-446655440000");
+        let fixtures_id = uuid!("550e8400-e29b-41d4-a716-446655440001");
+        let info = serde_json::from_value(serde_json::json!({
+          "id": id,
+          "fixtures_id": fixtures_id,
+          "spot_name": "test",
+          "lending_at": "2023-08-07 15:56:35 UTC",
+          "borrower_name": "test",
+          "borrower_number": 202200000,
+          "borrower_org": "jsys"
+        }))
+        .unwrap();
+        let res = insert_lending(&pool, info).await;
+        assert!(res.is_ok());
+
+        let new_info = serde_json::from_value(serde_json::json!({
+          "id": id,
+          "fixtures_id": fixtures_id,
+          "spot_name": "test",
+          "lending_at": "2023-08-16 15:56:35 UTC",
+          "borrower_name": "test2",
+          "borrower_number": 202200000,
+          "borrower_org": "jsys"
+        }))
+        .unwrap();
+        let res = update_lending(&pool, new_info).await;
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION
close #43 

全部の項目を変更できるようになっている
保護したい項目があったら、処理を追加してほしい